### PR TITLE
Feature/add interceptor to http request

### DIFF
--- a/client-app/src/app/app-routing.module.ts
+++ b/client-app/src/app/app-routing.module.ts
@@ -22,7 +22,6 @@ const routes: Routes = [
       {
         path: 'login/:id',
         component: UserDetailComponent,
-
       }
     ]
   },

--- a/client-app/src/app/app.module.ts
+++ b/client-app/src/app/app.module.ts
@@ -9,7 +9,8 @@ import { UserListComponent } from './components/dashboard/user-list/user-list.co
 import { UserDetailComponent } from './components/dashboard/user-detail/user-detail.component';
 import { DashboardHeaderComponent } from './components/dashboard/dashboard-header/dashboard-header.component';
 import { DefaultUserDetailComponent } from './components/dashboard/default-user-detail/default-user-detail.component';
-import {HttpClientModule} from '@angular/common/http';
+import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
+import {ApiInterceptor} from './interceptors/api.interceptor';
 
 @NgModule({
   declarations: [
@@ -26,7 +27,13 @@ import {HttpClientModule} from '@angular/common/http';
     AppRoutingModule,
     HttpClientModule
   ],
-  providers: [],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: ApiInterceptor,
+      multi: true
+    }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/client-app/src/app/components/dashboard/user-list/user-list.component.ts
+++ b/client-app/src/app/components/dashboard/user-list/user-list.component.ts
@@ -26,7 +26,7 @@ export class UserListComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.http.get<User[]>('http://localhost:3000/users').subscribe((res) => this.users = res);
+    this.http.get<User[]>('users').subscribe((res) => this.users = res);
   }
 
   getUserStatus(user: User) {
@@ -56,6 +56,6 @@ export class UserListComponent implements OnInit {
 
   onUserClicked(user: User) {
     console.log(user._id);
-    this.http.get<User>(`http://localhost:3000/users/${user._id}`).subscribe((res) => console.log(res));
+    this.http.get<User>(`users/${user._id}`).subscribe((res) => console.log(res));
   }
 }

--- a/client-app/src/app/interceptors/api.interceptor.ts
+++ b/client-app/src/app/interceptors/api.interceptor.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class ApiInterceptor implements HttpInterceptor {
+
+  constructor() {}
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    console.log('Requestin', request);
+    return next.handle(request);
+  }
+}

--- a/client-app/src/app/interceptors/api.interceptor.ts
+++ b/client-app/src/app/interceptors/api.interceptor.ts
@@ -9,11 +9,14 @@ import { Observable } from 'rxjs';
 
 @Injectable()
 export class ApiInterceptor implements HttpInterceptor {
+  private API_URL = 'http://localhost:3000';
 
   constructor() {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    console.log('Requestin', request);
-    return next.handle(request);
+    const apiRequest = request.clone({
+      url: `${(this.API_URL)}/${request.url}`
+    });
+    return next.handle(apiRequest);
   }
 }


### PR DESCRIPTION
This is super cool, I just learned about interceptors. Basically, every httpclient request will go through the interceptor first, and I am prepending the api url to the request. That means that all we have to do when calling the http client is to pass the path we want it to request and it will automatically use the api url.
Instead of this:
`
    this.http.get<User[]>('http://localhost:3000/users').subscribe((res) => this.users = res);
`
We can just do this now and get the same result
`    this.http.get<User[]>('users').subscribe((res) => this.users = res);
`
